### PR TITLE
Add link to mainnet/testnet in `More` dropdowns

### DIFF
--- a/src/layout/navbar.tsx
+++ b/src/layout/navbar.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import Image from 'next/image';
 import Link from 'next/link';
-import { IoSettingsOutline, IoBookOutline } from 'react-icons/io5';
+import {
+  IoSettingsOutline,
+  IoBookOutline,
+  IoTrailSignOutline,
+} from 'react-icons/io5';
 import { FaGithub, FaTelegramPlane } from 'react-icons/fa';
 import {
   Dropdown,
@@ -14,6 +18,7 @@ import {
 
 import { useAccount } from 'wagmi';
 import SettingsModal from './SettingsModal';
+import { isTestnet } from '../config/environment';
 
 const Navbar = () => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -40,6 +45,20 @@ const Navbar = () => {
             </Button>
           </DropdownTrigger>
           <DropdownMenu aria-label="More actions">
+            <DropdownItem>
+              <Link
+                href={
+                  isTestnet
+                    ? 'https://www.rollupfortress.xyz/'
+                    : 'https://testnet.rollupfortress.xyz/'
+                }
+                target="_blank"
+                className="flex items-center gap-2"
+              >
+                <IoTrailSignOutline size={18} />
+                {isTestnet ? 'Mainnets' : 'Testnets'}
+              </Link>
+            </DropdownItem>
             <DropdownItem>
               <Link
                 href="https://rollup-fortress.github.io/uncensored-book/"


### PR DESCRIPTION
Shows link to testnet if in mainnet page
<img width="252" alt="截圖 2025-02-21 下午4 39 32" src="https://github.com/user-attachments/assets/1cb4bed0-8204-4ddc-bd3d-517d4ae1c143" />

and link to mainnet if in testnet page
<img width="231" alt="截圖 2025-02-21 下午4 41 01" src="https://github.com/user-attachments/assets/cbfae5cf-b881-4507-9424-d9de45a12c5b" />
